### PR TITLE
Update debian instructions

### DIFF
--- a/doc/include/tab-repository.md
+++ b/doc/include/tab-repository.md
@@ -21,12 +21,12 @@
     apt update
     apt -y install apt-transport-https wget gnupg
 
-    wget -O - https://packages.icinga.com/icinga.key | apt-key add -
+    wget -O - https://packages.icinga.com/icinga.key | gpg --dearmor -o /usr/share/keyrings/icinga-archive-keyring.gpg
 
     DIST=$(awk -F"[)(]+" '/VERSION=/ {print $2}' /etc/os-release); \
-    echo "deb https://packages.icinga.com/debian icinga-${DIST} main" > \
+    echo "deb [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/debian icinga-${DIST} main" > \
     /etc/apt/sources.list.d/${DIST}-icinga.list
-    echo "deb-src https://packages.icinga.com/debian icinga-${DIST} main" >> \
+    echo "deb-src [signed-by=/usr/share/keyrings/icinga-archive-keyring.gpg] https://packages.icinga.com/debian icinga-${DIST} main" >> \
     /etc/apt/sources.list.d/${DIST}-icinga.list
 
     apt update


### PR DESCRIPTION
Update Debian 12 instructions because `apt-key` is deprecated.