### PR TITLE
Drop Debian Stretch Notes

### DIFF
--- a/doc/include/tab-repository.md
+++ b/doc/include/tab-repository.md
@@ -32,20 +32,6 @@
     apt update
     ```
 
-    **Debian Backports Repository**
-
-    This repository is required for Debian Stretch since Icinga v2.11.
-
-    Debian Stretch:
-
-    ```bash
-    DIST=$(awk -F"[)(]+" '/VERSION=/ {print $2}' /etc/os-release); \
-    echo "deb https://deb.debian.org/debian ${DIST}-backports main" > \
-    /etc/apt/sources.list.d/${DIST}-backports.list
-
-    apt update
-    ```
-
 === "SLES"
 
     !!! Info


### PR DESCRIPTION
Debian Stretch went EOL five years ago. There is no need to mention it here as a special case.