### PR TITLE
10-quickstart.md: Bump MySQL/MariaDB Requirements

### DIFF
--- a/doc/10-quickstart.md
+++ b/doc/10-quickstart.md
@@ -14,7 +14,7 @@ Icinga consists of multiple components, each responsible for different aspects o
 
 ### Requirements
 
-A database is required to store the monitoring data collected by Icinga. For this guide, MySQL > 5.7 or MariaDB > 10.2 is required.
+A database is required to store the monitoring data collected by Icinga. For this guide, MySQL ≥ 8.0 or MariaDB ≥ 10.2.2 is required.
 
 The commands listed below should be run with root permissions unless specified otherwise.
 


### PR DESCRIPTION
The minimum MySQL/MariaDB versions were bumped in Icinga DB 1.4.0.

https://icinga.com/docs/icinga-db/latest/doc/04-Upgrading/#upgrading-to-icinga-db-v140